### PR TITLE
Raised scalajs to 0.6.7 and changed to a provided configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ organization := "com.vmunier"
 
 homepage := Some(url("https://github.com/vmunier/sbt-play-scalajs"))
 
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.6")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.7" % "provided")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-web" % "1.2.2")
 


### PR DESCRIPTION
Currently I changed the scope of the dependency to "provided" which means that if scalajs 0.6.8 and 0.6.7 has the same public interfaces that you use, you could actually just switch the scalajs version in your project instead of on this library.
So this would work:
```
addSbtPlugin("com.vmunier" % "sbt-play-scalajs" % "0.2.10")
addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.6")
```

And this, too:
```
addSbtPlugin("com.vmunier" % "sbt-play-scalajs" % "0.2.10")
addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.7")
```

Currently you would get evicted warnings if you would do that.
